### PR TITLE
Twitterのリンク削除

### DIFF
--- a/resources/ts/entities/ExternalLinks.ts
+++ b/resources/ts/entities/ExternalLinks.ts
@@ -15,12 +15,6 @@ export const ExternalLinks: ExternalLink[] = [
     imgSrc: '/img/index/brands/bsky_blue.svg',
   },
   {
-    name: 'X (Information)',
-    sns_id: '@99no_exit',
-    href: 'https://twitter.com/99no_exit',
-    faIcon: ['fab', 'x-twitter'],
-  },
-  {
     name: 'Github',
     sns_id: 'nonuplet',
     href: 'https://github.com/nonuplet',

--- a/resources/ts/entities/SocialLinks.ts
+++ b/resources/ts/entities/SocialLinks.ts
@@ -16,11 +16,6 @@ export const SocialLinks: SocialLink[] = [
     href: '/blog',
   },
   {
-    title: 'Twitter',
-    css: 'twitter',
-    href: 'https://twitter.com/99no_exit',
-  },
-  {
     title: 'Github',
     css: 'github',
     href: 'https://github.com/nonuplet',

--- a/resources/vue/components/IndexLinks.vue
+++ b/resources/vue/components/IndexLinks.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
-import { faXTwitter, faGithub } from '@fortawesome/free-brands-svg-icons'
+import { faGithub } from '@fortawesome/free-brands-svg-icons'
 import { faSquarePen } from '@fortawesome/free-solid-svg-icons'
 import { library } from '@fortawesome/fontawesome-svg-core'
 import { ExternalLinks } from '../../ts/entities/ExternalLinks'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 
-library.add(faXTwitter, faGithub, faSquarePen)
+library.add(faGithub, faSquarePen)
 const links = ExternalLinks
 </script>
 


### PR DESCRIPTION
Blueskyが一般開放されて普及してきたため、Twitterが不要になったことからリンクを完全に削除